### PR TITLE
Fix hash computing to be 16 characters exactly

### DIFF
--- a/lib/opensubtitles.js
+++ b/lib/opensubtitles.js
@@ -52,6 +52,7 @@ os.prototype.computeHash = function(path, cb) {
 		if(t_chksum.length == 3) {
 			var chksum = this.sumHex64bits(t_chksum[0], t_chksum[1]);
 			chksum = this.sumHex64bits(chksum, t_chksum[2]);
+			chksum = chksum.substr(-16);
 			cb(null, self.padLeft(chksum, '0', 16));
 		}
 	});


### PR DESCRIPTION
Adding two 64bits hex via sumHex64bits method can return sometimes a 17-character hash.
You can have a 'retenue' when computing h_0 (line 159 in opensubtitles.js) just like computing h_1.
Opensubtitles API relies on 16 characters hashes (cf. http://trac.opensubtitles.org/projects/opensubtitles/wiki/HashSourceCodes#C2)
