### PR TITLE
Close FS after Calculating Hash

### DIFF
--- a/lib/opensubtitles.js
+++ b/lib/opensubtitles.js
@@ -78,6 +78,7 @@ os.prototype.computeHash = function(path, cb) {
           checksumReady(self.checksumBuffer(buffer, 16), "buf?");
 				});
 			}
+			fs.close(fd);
 		});
 	});
 };


### PR DESCRIPTION
Otherwise (on Windows at least) no other process will be allowed to
interact with or delete the file, receiving a EPERM error. (ie: operation not
permitted)
